### PR TITLE
Register the database context

### DIFF
--- a/TodoApiSwag/Models/TodoContext.cs
+++ b/TodoApiSwag/Models/TodoContext.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System.Diagnostics.CodeAnalysis;
 
-namespace TodoApi.Models
+namespace TodoApi.Models 
 {
     public class TodoContext : DbContext
     {

--- a/TodoApiSwag/Program.cs
+++ b/TodoApiSwag/Program.cs
@@ -1,19 +1,26 @@
+using Microsoft.EntityFrameworkCore; 
+using TodoApi.Models;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
-builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddControllers(); 
 
-var app = builder.Build();
+
+builder.Services.AddControllers(); 
+builder.Services.AddDbContext<TodoContext>(opt => 
+    opt.UseInMemoryDatabase("TodoList"));
+// Adds the database context to the DI container.
+// Specifies that the database context will use an in-memory database.
+
+var app = builder.Build(); 
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment()) 
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseDeveloperExceptionPage(); 
+    
 }
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
In ASP.NET Core, services such as the DB context must be registered with the [dependency injection (DI)](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-6.0) container. The container provides the service to controllers.

The preceding code:

Removes the Swagger calls.
Removes unused using directives.
Adds the database context to the DI container.
Specifies that the database context will use an in-memory database.