### PR TITLE
Update the PostTodoItem create method

### DIFF
--- a/TodoApiSwag/Controllers/TodoItemsController.cs
+++ b/TodoApiSwag/Controllers/TodoItemsController.cs
@@ -85,14 +85,10 @@ namespace TodoApiSwag.Controllers
         [HttpPost]
         public async Task<ActionResult<TodoItem>> PostTodoItem(TodoItem todoItem)
         {
-          if (_context.TodoItems == null)
-          {
-              return Problem("Entity set 'TodoContext.TodoItems'  is null.");
-          }
-            _context.TodoItems.Add(todoItem);
-            await _context.SaveChangesAsync();
+          _context.TodoItems.Add(todoItem);
+            await _context.SaveChangesAsync(); // This is the line that actually saves the data to the database.
 
-            return CreatedAtAction("GetTodoItem", new { id = todoItem.Id }, todoItem);
+            return CreatedAtAction(nameof(GetTodoItem),new { id = todoItem.Id }, todoItem); // This line returns an HTTP 201 status code. HTTP 201 is the standard response for an HTTP POST method that creates a new resource on the server.
         }
 
         // DELETE: api/TodoItems/5

--- a/TodoApiSwag/TodoApiSwag.csproj
+++ b/TodoApiSwag/TodoApiSwag.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.20">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.15" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update the return statement in the PostTodoItem to use the nameof operator.

The preceding code is an HTTP POST method, as indicated by the HttpPost attribute. The method gets the value of the to-do item from the body of the HTTP request.

The CreatedAtAction method:

Returns an HTTP 201 status code if successful. HTTP 201 is the standard response for an HTTP POST method that creates a new resource on the server.

Adds a Location header to the response. The Location header specifies the URI of the newly created to-do item. 

References the GetTodoItem action to create the Location header's URI. 

The C# nameof keyword is used to avoid hard-coding the action name in the CreatedAtAction call.